### PR TITLE
Adding more flags to 'btrace' and 'btracer' launchers

### DIFF
--- a/bin/btrace
+++ b/bin/btrace
@@ -36,7 +36,7 @@ if [ -f "${BTRACE_HOME}/build/btrace-client.jar" ] ; then
               TOOLS_JAR="${JAVA_HOME}/lib/tools.jar"
           ;;
        esac
-       ${JAVA_HOME}/bin/java -Dcom.sun.btrace.probeDescPath=. -Dcom.sun.btrace.dumpClasses=false -Dcom.sun.btrace.debug=false -Dcom.sun.btrace.unsafe=false -cp ${BTRACE_HOME}/build/btrace-client.jar:${TOOLS_JAR}:/usr/share/lib/java/dtrace.jar com.sun.btrace.client.Main $*
+       ${JAVA_HOME}/bin/java -cp ${BTRACE_HOME}/build/btrace-client.jar:${TOOLS_JAR}:/usr/share/lib/java/dtrace.jar com.sun.btrace.client.Main $*
     else
        echo "Please set JAVA_HOME before running this script"
        exit 1

--- a/bin/btracec
+++ b/bin/btracec
@@ -10,6 +10,11 @@ fi
 
 if [ -f "${BTRACE_HOME}/build/btrace-client.jar" ] ; then
     if [ "${JAVA_HOME}" != "" ]; then
+        if [ "$1" = "--version" ]
+        then
+          ${JAVA_HOME}/bin/java -jar ${BTRACE_HOME}/build/btrace-client.jar com.sun.btrace.Main --version
+          exit 0
+        fi
         case "`uname`" in
           Darwin*)
               if [ -f /System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Classes/classes.jar ]; then

--- a/bin/btracec.bat
+++ b/bin/btracec.bat
@@ -9,6 +9,10 @@ set DEFAULT_BTRACE_HOME=
 if not exist "%BTRACE_HOME%\build\btrace-client.jar" goto noBTraceHome
 
 if "%JAVA_HOME%" == "" goto noJavaHome
+  if "%1" == "--version" (
+    %JAVA_HOME%\bin\java -jar %BTRACE_HOME%/build/btrace-client.jar com.sun.btrace.Main --version
+    goto end
+  )
   "%JAVA_HOME%/bin/java" -cp "%BTRACE_HOME%/build/btrace-client.jar;%JAVA_HOME%/lib/tools.jar" com.sun.btrace.compiler.Compiler %*
   goto end
 :noJavaHome

--- a/bin/btracer
+++ b/bin/btracer
@@ -8,8 +8,81 @@ if [ -z "$BTRACE_HOME" -o ! -d "$BTRACE_HOME" ] ; then
   BTRACE_HOME=`cd "$BTRACE_HOME" && pwd`
 fi
 
+usage() {
+  echo "btracer <options> <compiled script> <java args>"
+  echo "Options:"
+  echo "    -v\t\tRun in verbose mode"
+  echo "    -u\t\tRun in unsafe mode"
+  echo "    -p <port>\tBTrace agent server port"
+  echo "    -o <file>\tThe path to a file the btrace agent will store its output"
+  echo "    -d <path>\tDump modified classes to the provided location"
+  echo "    -pd <path>\tSearch for the probe XML descriptors here"
+  echo "    --noserver\tDon't start the socket server"
+  echo "    --stdout\tRedirect the btrace output to stdout instead of writing it to an arbitrary file"
+  echo "    -bcp <cp>\tAppend to bootstrap class path"
+  echo "    -scp <cp>\tAppend to system class path"
+  echo "    -h\t\tThis message"
+  exit 0
+}
+
+if [ $# -eq 0 ]
+then
+  usage
+fi
+
+OPTIONS=
+
+while [ true ]
+do
+  case $1 in
+    -v)
+      OPTIONS="debug=true,$OPTIONS"
+      ;;
+    -u)
+      OPTIONS="unsafe=true,$OPTIONS"
+      ;;
+    -p)
+      OPTIONS="port=$2,$OPTIONS"
+      shift
+      ;;
+    -d)
+      OPTIONS="dumpClasses=true,dumpDir=$2,$OPTIONS"
+      shift
+      ;;
+    -o)
+      OPTIONS="scriptOutputFile=$2,$OPTIONS"
+      shift
+      ;;
+    -pd)
+      OPTIONS="probeDescPath=$2,$OPTIONS"
+      shift
+      ;;
+    -bcp)
+      OPTIONS="bootClassPath=$2,$OPTIONS"
+      shift
+      ;;
+    -scp)
+      OPTIONS="systemClassPath=$2,$OPTIONS"
+      shift
+      ;;
+    --noserver)
+      OPTIONS="noServer=true,$OPTIONS"
+      ;;
+    --stdout)
+      OPTIONS="stdout=true,$OPTIONS"
+      ;;
+    -h)
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+  shift
+done
+
 if [ -f "${BTRACE_HOME}/build/btrace-agent.jar" ] ; then
-    java -Xshare:off -javaagent:${BTRACE_HOME}/build/btrace-agent.jar=dumpClasses=false,debug=false,unsafe=false,probeDescPath=.,noServer=true,script=$1 $2 $3 $4 $5 $6 $7 $8 $9
+    java -Xshare:off -javaagent:${BTRACE_HOME}/build/btrace-agent.jar=$OPTIONS,script=$1 $2 $3 $4 $5 $6 $7 $8 $9
 else
     echo "Please set BTRACE_HOME before running this script"
 fi

--- a/bin/btracer
+++ b/bin/btracer
@@ -11,6 +11,7 @@ fi
 usage() {
   echo "btracer <options> <compiled script> <java args>"
   echo "Options:"
+  echo "    --version\tShow BTrace version"
   echo "    -v\t\tRun in verbose mode"
   echo "    -u\t\tRun in unsafe mode"
   echo "    -p <port>\tBTrace agent server port"
@@ -32,58 +33,66 @@ fi
 
 OPTIONS=
 
-while [ true ]
-do
-  case $1 in
-    -v)
-      OPTIONS="debug=true,$OPTIONS"
-      ;;
-    -u)
-      OPTIONS="unsafe=true,$OPTIONS"
-      ;;
-    -p)
-      OPTIONS="port=$2,$OPTIONS"
+if [ "${JAVA_HOME}" != "" ]; then
+    while [ true ]
+    do
+      case $1 in
+        -v)
+          OPTIONS="debug=true,$OPTIONS"
+          ;;
+        -u)
+          OPTIONS="unsafe=true,$OPTIONS"
+          ;;
+        -p)
+          OPTIONS="port=$2,$OPTIONS"
+          shift
+          ;;
+        -d)
+          OPTIONS="dumpClasses=true,dumpDir=$2,$OPTIONS"
+          shift
+          ;;
+        -o)
+          OPTIONS="scriptOutputFile=$2,$OPTIONS"
+          shift
+          ;;
+        -pd)
+          OPTIONS="probeDescPath=$2,$OPTIONS"
+          shift
+          ;;
+        -bcp)
+          OPTIONS="bootClassPath=$2,$OPTIONS"
+          shift
+          ;;
+        -scp)
+          OPTIONS="systemClassPath=$2,$OPTIONS"
+          shift
+          ;;
+        --noserver)
+          OPTIONS="noServer=true,$OPTIONS"
+          ;;
+        --stdout)
+          OPTIONS="stdout=true,$OPTIONS"
+          ;;
+        --version)
+          $JAVA_HOME/bin/java -jar ${BTRACE_HOME}/build/btrace-client.jar com.sun.btrace.Main --version
+          exit 0
+          ;;
+        -h)
+          usage
+          ;;
+        *)
+          break
+          ;;
+      esac
       shift
-      ;;
-    -d)
-      OPTIONS="dumpClasses=true,dumpDir=$2,$OPTIONS"
-      shift
-      ;;
-    -o)
-      OPTIONS="scriptOutputFile=$2,$OPTIONS"
-      shift
-      ;;
-    -pd)
-      OPTIONS="probeDescPath=$2,$OPTIONS"
-      shift
-      ;;
-    -bcp)
-      OPTIONS="bootClassPath=$2,$OPTIONS"
-      shift
-      ;;
-    -scp)
-      OPTIONS="systemClassPath=$2,$OPTIONS"
-      shift
-      ;;
-    --noserver)
-      OPTIONS="noServer=true,$OPTIONS"
-      ;;
-    --stdout)
-      OPTIONS="stdout=true,$OPTIONS"
-      ;;
-    -h)
-      usage
-      ;;
-    *)
-      break
-      ;;
-  esac
-  shift
-done
+    done
 
-if [ -f "${BTRACE_HOME}/build/btrace-agent.jar" ] ; then
-    java -Xshare:off -javaagent:${BTRACE_HOME}/build/btrace-agent.jar=$OPTIONS,script=$1 $2 $3 $4 $5 $6 $7 $8 $9
+    if [ -f "${BTRACE_HOME}/build/btrace-agent.jar" ] ; then
+        ${JAVA_HOME}/bin/java -Xshare:off -javaagent:${BTRACE_HOME}/build/btrace-agent.jar=$OPTIONS,script=$1 $2 $3 $4 $5 $6 $7 $8 $9
+    else
+        echo "Please set BTRACE_HOME before running this script"
+    fi
 else
-    echo "Please set BTRACE_HOME before running this script"
+    echo "Please set JAVA_HOME before running this script"
+    exit 1
 fi
-

--- a/bin/btracer.bat
+++ b/bin/btracer.bat
@@ -8,11 +8,93 @@ set DEFAULT_BTRACE_HOME=
 
 if not exist "%BTRACE_HOME%\build\btrace-agent.jar" goto noBTraceHome
 
-echo Output sent to C:\Temp\%~n1.txt
+set OPTIONS=
 
-java -Xshare:off "-javaagent:%BTRACE_HOME%/build/btrace-agent.jar=dumpClasses=false,debug=true,unsafe=false,probeDescPath=.,noServer=true,scriptOutputFile=C:\Temp\%~n1.txt,script=%~1" %2 %3 %4 %5 %6 %7 %8 %9
+if "%1"=="" (
+  call:usage
+  goto end
+)
+
+set inloop=1
+:loop
+  IF "%1"=="-v" (
+    set OPTIONS="debug=true,%OPTIONS"
+    goto next
+  )
+  IF "%1"=="-u" (
+    set OPTIONS="unsafe=true,%OPTIONS"
+    goto next
+  )
+  if "%1"=="-p" (
+    set OPTIONS="port=%2,%OPTIONS"
+    shift
+    goto next
+  )
+  if "%1"=="-d" (
+    set OPTIONS="dumpClasses=true,dumpDir=%2,%OPTIONS"
+     shift
+    goto next
+  )
+  if "%1"=="-o" (
+    set OPTIONS="scriptOutputFile=%2,%OPTIONS"
+    shift
+    goto next
+  )
+  if "%1"=="-pd" (
+    set OPTIONS="probeDescPath=%2,%OPTIONS"
+    shift
+    goto next
+  )
+  if "%1"=="-bcp" (
+    OPTIONS="bootClassPath=%2,%OPTIONS"
+    shift
+    goto next
+  )
+  if "%1"=="-scp" (
+    set OPTIONS="systemClassPath=%2,%OPTIONS"
+    shift
+    goto next
+  )
+  if "%1"=="--noserver" (
+    set OPTIONS="noServer=true,%OPTIONS"
+    goto next
+  )
+  if "%1"=="--stdout" (
+    set OPTIONS="stdout=true,%OPTIONS"
+    goto next
+  )
+  if "%1"=="-h" (
+    call :usage
+    goto end
+  )
+  set inloop=0
+
+  :next
+  if %inloop==1 (
+    shift
+    goto loop
+  )
+
+java -Xshare:off "-javaagent:%BTRACE_HOME%/build/btrace-agent.jar=%OPTIONS,script=%~1" %2 %3 %4 %5 %6 %7 %8 %9
 goto end
 
 :noBTraceHome
   echo Please set BTRACE_HOME before running this script
+  goto end
+
+:usage
+  echo btracer ^<options^> ^<compiled script^> ^<java args^>
+  echo Options:
+  echo     -v		Run in verbose mode
+  echo     -u		Run in unsafe mode
+  echo     -p ^<port^>	BTrace agent server port
+  echo     -o ^<file^>	The path to a file the btrace agent will store its output
+  echo     -d ^<path^>	Dump modified classes to the provided location
+  echo     -pd ^<path^>	Search for the probe XML descriptors here
+  echo     --noserver	Don't start the socket server
+  echo     --stdout	Redirect the btrace output to stdout instead of writing it to an arbitrary file
+  echo     -bcp ^<cp^>	Append to bootstrap class path
+  echo     -scp ^<cp^>	Append to system class path
+  echo     -h		This message
+
 :end

--- a/bin/btracer.bat
+++ b/bin/btracer.bat
@@ -14,6 +14,12 @@ if "%1"=="" (
   call:usage
   goto end
 )
+if "%JAVA_HOME%" == "" goto noJavaHome
+
+if "%1" == "--version" (
+  %JAVA_HOME%\bin\java -jar %BTRACE_HOME%/build/btrace-client.jar com.sun.btrace.Main --version
+  goto end
+)
 
 set inloop=1
 :loop
@@ -75,9 +81,12 @@ set inloop=1
     goto loop
   )
 
-java -Xshare:off "-javaagent:%BTRACE_HOME%/build/btrace-agent.jar=%OPTIONS,script=%~1" %2 %3 %4 %5 %6 %7 %8 %9
+%JAVA_HOME%\bin\java -Xshare:off "-javaagent:%BTRACE_HOME%/build/btrace-agent.jar=%OPTIONS,script=%~1" %2 %3 %4 %5 %6 %7 %8 %9
 goto end
 
+:noJavaHome
+  echo Please set JAVA_HOME before running this script
+  goto end
 :noBTraceHome
   echo Please set BTRACE_HOME before running this script
   goto end

--- a/make/build.xml
+++ b/make/build.xml
@@ -9,7 +9,7 @@
     <property name="agent.excludes" value="**/dtrace/* **/btrace/*.class **/asm/signature/** **/asm/tree/** **/asm/util/** **/asm/xml/** **/aggregation/* **/compiler/* **/client/* **/comm/* com/sun/btrace/api/**/* com/sun/btrace/spi/**/* **/instr/** **/META-INF/*"/>
     <property name="boot.excludes" value="**/dtrace/* **/agent/* **/compiler/* **/client/* **/resources/* **/runtime/* **/util/**/* **/asm/** com/sun/btrace/api/**/* com/sun/btrace/spi/**/*"/>
     <property name="client.excludes" value="**/runtime/* **/agent/* **/util/TimeStamp* **/util/MethodId **/util/SamplingSupport **/util/templates/**/* **/instr/** **/META-INF/*"/>
-
+    
     <target name="prepare" depends="load.properties">
         <mkdir dir="${classes.dir}"/>
         <mkdir dir="${javadoc.dir}"/>
@@ -244,6 +244,9 @@
         </javac>
     </target>
     <target name="compile" depends="compile-src, compile-dtrace" description="Compiles the sources, resources and javadocs">
+        <tstamp>
+            <format property="build.date" pattern="YYYYMMdd"/>
+        </tstamp>
         <copy todir="${classes.dir}/com/sun/btrace/resources">
             <fileset dir="${share.src.dir}/com/sun/btrace/resources/"/>
         </copy>
@@ -253,6 +256,8 @@
         <copy todir="${classes.dir}/com/sun/btrace/annotations">
             <fileset file="${share.src.dir}/com/sun/btrace/annotations/jaxb.index"/>
         </copy>
+        <echo>${build.date}</echo>
+        <replace file="${classes.dir}/com/sun/btrace/resources/messages.properties" value="${release.version} (${build.date})" token="{btrace.version}"/>
     </target>
     <target name="javadoc" depends="jar,clean-docs" description="Generates javadocs">
         <javadoc destdir="${javadoc.dir}">

--- a/src/share/classes/com/sun/btrace/client/Main.java
+++ b/src/share/classes/com/sun/btrace/client/Main.java
@@ -54,7 +54,7 @@ public final class Main {
     private static String PROBE_DESC_PATH;
     public static final boolean TRACK_RETRANSFORM;
     public static final int BTRACE_DEFAULT_PORT = 2020;
-    
+
     private static final Console con;
     private static final PrintWriter out;
     static {
@@ -74,7 +74,7 @@ public final class Main {
         con = System.console();
         out = (con != null)? con.writer() : new PrintWriter(System.out);
     }
-    
+
     public static void main(String[] args) {
         if (args.length < 2) {
             usage();
@@ -83,24 +83,28 @@ public final class Main {
         int port = BTRACE_DEFAULT_PORT;
         String classPath = ".";
         String includePath = null;
-        
+
         int count = 0;
         boolean portDefined = false;
         boolean classpathDefined = false;
         boolean includePathDefined = false;
 
         // scan for "-v" to set DEBUG mode before anything interesting happens
+        // when "--version" is specified just print the version and exit
         for(String arg : args) {
             if (arg.equals("-v")) {
                 DEBUG = true;
                 break;
+            } else if (arg.equals("--version")) {
+                System.out.println(Messages.get("btrace.version"));
+                return;
             }
         }
         for (;;) {
             if (args[count].charAt(0) == '-') {
                 if (args.length <= count+1) {
                     usage();
-                }  
+                }
                 if (args[count].equals("-p") && !portDefined) {
                     try {
                         port = Integer.parseInt(args[++count]);
@@ -163,13 +167,13 @@ public final class Main {
         }
 
         try {
-            Client client = new Client(port, PROBE_DESC_PATH, 
+            Client client = new Client(port, PROBE_DESC_PATH,
                 DEBUG, TRACK_RETRANSFORM, UNSAFE, DUMP_CLASSES, DUMP_DIR);
             if (! new File(fileName).exists()) {
                 errorExit("File not found: " + fileName, 1);
             }
             byte[] code = client.compile(fileName, classPath, includePath);
-            if (code == null) { 
+            if (code == null) {
                 errorExit("BTrace compilation failed", 1);
             }
             client.attach(pid);
@@ -225,8 +229,8 @@ public final class Main {
     }
 
     private static void registerSignalHandler(final Client client) {
-        if (isDebug()) debugPrint("registering signal handler for SIGINT");            
-        Signal.handle(new Signal("INT"), 
+        if (isDebug()) debugPrint("registering signal handler for SIGINT");
+        Signal.handle(new Signal("INT"),
             new SignalHandler() {
                 public void handle(Signal sig) {
                     try {
@@ -238,7 +242,7 @@ public final class Main {
                         if (option == null) {
                             return;
                         }
-                        if (option.equals("1")) {                            
+                        if (option.equals("1")) {
                             System.exit(0);
                         } else if (option.equals("2")) {
                             if (isDebug()) debugPrint("sending event command");

--- a/src/share/classes/com/sun/btrace/client/Main.java
+++ b/src/share/classes/com/sun/btrace/client/Main.java
@@ -47,12 +47,12 @@ import com.sun.btrace.util.Messages;
  */
 public final class Main {
     public static volatile boolean exiting;
-    public static final boolean DEBUG;
+    private static boolean DEBUG;
+    private static boolean UNSAFE;
+    private static  boolean DUMP_CLASSES;
+    private static String DUMP_DIR;
+    private static String PROBE_DESC_PATH;
     public static final boolean TRACK_RETRANSFORM;
-    public static final boolean UNSAFE;
-    public static final boolean DUMP_CLASSES;
-    public static final String DUMP_DIR;
-    public static final String PROBE_DESC_PATH;
     public static final int BTRACE_DEFAULT_PORT = 2020;
     
     private static final Console con;
@@ -89,6 +89,13 @@ public final class Main {
         boolean classpathDefined = false;
         boolean includePathDefined = false;
 
+        // scan for "-v" to set DEBUG mode before anything interesting happens
+        for(String arg : args) {
+            if (arg.equals("-v")) {
+                DEBUG = true;
+                break;
+            }
+        }
         for (;;) {
             if (args[count].charAt(0) == '-') {
                 if (args.length <= count+1) {
@@ -102,6 +109,16 @@ public final class Main {
                         usage();
                     }
                     portDefined = true;
+                } else if (args[count].equals("-u")) {
+                    UNSAFE = true;
+                    if (isDebug()) debugPrint("btrace unsafe mode is set");
+                } else if (args[count].equals("-d")) {
+                    DUMP_CLASSES = true;
+                    DUMP_DIR = args[++count];
+                    if (isDebug()) debugPrint("dumpDir is " + DUMP_DIR);
+                } else if (args[count].equals("-pd")) {
+                    PROBE_DESC_PATH = args[++count];
+                    if (isDebug()) debugPrint("probeDescDir is " + PROBE_DESC_PATH);
                 } else if ((args[count].equals("-cp") ||
                     args[count].equals("-classpath"))
                     && !classpathDefined) {
@@ -112,6 +129,8 @@ public final class Main {
                     includePath = args[++count];
                     if (isDebug()) debugPrint("accepting include path " + includePath);
                     includePathDefined = true;
+                } else if (args[count].equals("-v")) {
+                    // already processed
                 } else {
                     usage();
                 }

--- a/src/share/classes/com/sun/btrace/resources/messages.properties
+++ b/src/share/classes/com/sun/btrace/resources/messages.properties
@@ -88,6 +88,6 @@ btrace.agent.usage =\
     stdout           redirect the btrace output to stdout instead of writing it to an arbitrary file (true/false)\n \
     scriptdir        the path to a directory containing scripts to be run at the agent startup\n \
     scriptOutputFile the path to a file the btrace agent will store its output\n \
-    script           comma separated list of compiled tracing scripts to be run at the agent startup; *MUST* be the last argument in the list\n  \
+    script           comma separated list of compiled tracing scripts to be run at the agent startup; *MUST* be the last argument in the list\n
 
-
+btrace.version = BTrace v.{btrace.version}

--- a/src/share/classes/com/sun/btrace/resources/messages.properties
+++ b/src/share/classes/com/sun/btrace/resources/messages.properties
@@ -64,6 +64,10 @@ btracec.usage =\
 btrace.usage =\
   Usage: btrace <options> <pid> <btrace source or .class file> <btrace arguments>\n\
   where possible options include:\n  \
+    -v                Run in verbose mode\n  \
+    -u                Run in unsafe mode\n  \
+    -d <path>         Dump the instrumented classes to the specified path\n  \
+    -pd <path>        The search path for the probe XML descriptors\n  \
     -classpath <path> Specify where to find user class files and annotation processors\n  \
     -cp <path>        Specify where to find user class files and annotation processors\n  \
     -I <path>         Specify where to find include files\n  \


### PR DESCRIPTION
Fixes #106 

This patch adds the following flags to "btrace" launcher:
* **-v**                Run in verbose mode
* **-u**                Run in unsafe mode
* **-d <path>**    Dump the instrumented classes to the specified path
* **-pd <path>**  The search path for the probe XML descriptors

"btracer" launcher is enhanced by:
* **-v**                Run in verbose mode
* **-u**                Run in unsafe mode
* **-p <port>**    BTrace agent server port
* **-o <file>**      The path to a file the btrace agent will store its output
* **-d <path>**    Dump modified classes to the provided location
* **-pd <path>**  Search for the probe XML descriptors here
* **--noserver**   Don't start the socket server
* **--stdout**       Redirect the btrace output to stdout instead of writing it to an arbitrary file
* **-bcp <cp>**   Append to bootstrap class path
* **-scp <cp>**   Append to system class path
* **-h**                Help