### PR TITLE
[gradle] Enabling building and proper distribution of the DTrace lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,6 +177,20 @@ task buildTraces(type: Exec) {
 }
 
 
+task buildDTrace(type:Exec) {
+  group 'Build'
+  description 'Build the native library for DTrace integration'
+  onlyIf {osName == 'SunOS'}
+  inputs.dir 'src/solaris/native'
+  inputs.files bootJar.outputs
+  outputs.dir "${buildDir}/i386"
+
+  workingDir 'make'
+
+  commandLine 'make'
+}
+
+
 def distContent = copySpec {
   into('bin') {
     from 'bin'
@@ -207,16 +221,6 @@ def distContent = copySpec {
   }
 }
 
-task buildDTrace(type:Exec) {
-  group 'Build'
-  enabled = (osName == 'SunOS')
-
-  workingDir 'make'
-
-  commandLine 'make'
-
-  dependsOn 'bootJar'
-}
 
 task createBinDistZip(type: Zip) {
   group 'Build'
@@ -224,12 +228,12 @@ task createBinDistZip(type: Zip) {
   inputs.files agentJar.outputs
   inputs.files bootJar.outputs
   inputs.files clientJar.outputs
+  inputs.files buildDTrace.outputs
 
   appendix = 'bin'
   with distContent
-
-  dependsOn 'buildDTrace'
 }
+
 
 task createBinDistTgz(type: Tar) {
   group 'Build'
@@ -237,12 +241,12 @@ task createBinDistTgz(type: Tar) {
   inputs.files agentJar.outputs
   inputs.files bootJar.outputs
   inputs.files clientJar.outputs
+  inputs.files buildDTrace.outputs
+
   compression = Compression.GZIP
 
   appendix = 'bin'
   with distContent
-
-  dependsOn 'buildDTrace'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import javax.tools.ToolProvider
+
 plugins {
   id 'java'
   id 'maven-publish'

--- a/build.gradle
+++ b/build.gradle
@@ -294,6 +294,7 @@ test {
 
 dependencies {
   compile files("lib/btrace-asm-${asmVersion}.jar",
+                "${javaHome}/lib/tools.jar",  // ATTENTION: build.xml uses "${javaHome}/../lib/tools.jar"
                 files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()),
                 "/usr/share/lib/java/dtrace.jar")
 

--- a/build.gradle
+++ b/build.gradle
@@ -297,6 +297,7 @@ test {
 dependencies {
   compile files("lib/btrace-asm-${asmVersion}.jar",
                 "${javaHome}/lib/tools.jar",  // ATTENTION: build.xml uses "${javaHome}/../lib/tools.jar"
+                files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()),
                 "/usr/share/lib/java/dtrace.jar")
 
   testCompile files("test-lib/asm-all-${asmVersion}.jar",

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import javax.tools.ToolProvider
-
 plugins {
   id 'java'
   id 'maven-publish'
@@ -96,6 +94,7 @@ processTestResources {
   include 'traces/**/*.xml'
 }
 
+
 task unjar(type: Copy) {
   group 'Build'
   description 'Explode the pre-built asm jar.'
@@ -177,6 +176,7 @@ task buildTraces(type: Exec) {
   args fileTree(dir: "src/test/traces", include: '**/*.java')
 }
 
+
 task buildDTrace(type:Exec) {
   group 'Build'
   description 'Build the native library for DTrace integration'
@@ -221,6 +221,7 @@ def distContent = copySpec {
   }
 }
 
+
 task createBinDistZip(type: Zip) {
   group 'Build'
   description 'Build the binary distribution zip-file.'
@@ -232,6 +233,7 @@ task createBinDistZip(type: Zip) {
   appendix = 'bin'
   with distContent
 }
+
 
 task createBinDistTgz(type: Tar) {
   group 'Build'
@@ -295,7 +297,6 @@ test {
 dependencies {
   compile files("lib/btrace-asm-${asmVersion}.jar",
                 "${javaHome}/lib/tools.jar",  // ATTENTION: build.xml uses "${javaHome}/../lib/tools.jar"
-                files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()),
                 "/usr/share/lib/java/dtrace.jar")
 
   testCompile files("test-lib/asm-all-${asmVersion}.jar",

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ def javaHome = env['JAVA_HOME']
 
 def props = System.getProperties()
 def osFamily = props['os.family']
+def osName = props['os.name']
 
 def asmVersion = '5.0.2'
 def junitVersion = '4.6'
@@ -65,8 +66,6 @@ sourceSets {
     }
   }
 }
-
-
 
 processResources {
   from 'src/share/classes'
@@ -186,6 +185,7 @@ def distContent = copySpec {
   into('build') {
     from "$buildDir"
     include '*.jar'
+    include 'i386/*.so'
   }
 
   into ('docs') {
@@ -207,6 +207,17 @@ def distContent = copySpec {
   }
 }
 
+task buildDTrace(type:Exec) {
+  group 'Build'
+  enabled = (osName == 'SunOS')
+
+  workingDir 'make'
+
+  commandLine 'make'
+
+  dependsOn 'bootJar'
+}
+
 task createBinDistZip(type: Zip) {
   group 'Build'
   description 'Build the binary distribution zip-file.'
@@ -216,6 +227,8 @@ task createBinDistZip(type: Zip) {
 
   appendix = 'bin'
   with distContent
+
+  dependsOn 'buildDTrace'
 }
 
 task createBinDistTgz(type: Tar) {
@@ -228,6 +241,8 @@ task createBinDistTgz(type: Tar) {
 
   appendix = 'bin'
   with distContent
+
+  dependsOn 'buildDTrace'
 }
 
 
@@ -273,7 +288,6 @@ task buildDistributions {
 test {
   inputs.files buildTraces.outputs
 }
-
 
 dependencies {
   compile files("lib/btrace-asm-${asmVersion}.jar",

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import javax.tools.ToolProvider
+
 plugins {
   id 'java'
   id 'maven-publish'
@@ -94,7 +96,6 @@ processTestResources {
   include 'traces/**/*.xml'
 }
 
-
 task unjar(type: Copy) {
   group 'Build'
   description 'Explode the pre-built asm jar.'
@@ -176,7 +177,6 @@ task buildTraces(type: Exec) {
   args fileTree(dir: "src/test/traces", include: '**/*.java')
 }
 
-
 task buildDTrace(type:Exec) {
   group 'Build'
   description 'Build the native library for DTrace integration'
@@ -221,7 +221,6 @@ def distContent = copySpec {
   }
 }
 
-
 task createBinDistZip(type: Zip) {
   group 'Build'
   description 'Build the binary distribution zip-file.'
@@ -233,7 +232,6 @@ task createBinDistZip(type: Zip) {
   appendix = 'bin'
   with distContent
 }
-
 
 task createBinDistTgz(type: Tar) {
   group 'Build'
@@ -291,11 +289,12 @@ task buildDistributions {
 
 test {
   inputs.files buildTraces.outputs
+  inputs.files buildDTrace.outputs
 }
 
 dependencies {
   compile files("lib/btrace-asm-${asmVersion}.jar",
-                "${javaHome}/lib/tools.jar",  // ATTENTION: build.xml uses "${javaHome}/../lib/tools.jar"
+                files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()),
                 "/usr/share/lib/java/dtrace.jar")
 
   testCompile files("test-lib/asm-all-${asmVersion}.jar",

--- a/make/Makefile
+++ b/make/Makefile
@@ -7,9 +7,9 @@ OUTDIR=${BUILDDIR}/`uname -p`
 all:
 	${JAVA_HOME}/bin/javah -classpath ${BUILDDIR}/btrace-boot.jar -d ${OUTDIR} com.sun.btrace.BTraceRuntime
 	mkdir -p ${OUTDIR}
-	cc -c -I${JAVA_HOME}/include -I${JAVA_HOME}/include/solaris -I${OUTDIR} -o ${OUTDIR}/btrace.o ${SRCDIR}/solaris/native/btrace.c
+	${CC} -c -I${JAVA_HOME}/include -I${JAVA_HOME}/include/solaris -I${OUTDIR} -o ${OUTDIR}/btrace.o ${SRCDIR}/solaris/native/btrace.c
 	/usr/sbin/dtrace -G -o ${OUTDIR}/btraced.o -s ${SRCDIR}/solaris/native/btraced.d ${OUTDIR}/btrace.o
-	cc -G ${OUTDIR}/btrace.o ${OUTDIR}/btraced.o -o ${OUTDIR}/libbtrace.so
+	${CC} -G ${OUTDIR}/btrace.o ${OUTDIR}/btraced.o -o ${OUTDIR}/libbtrace.so
 
 clean:
 	rm -rf ${OUTDIR}

--- a/src/share/classes/com/sun/btrace/BTraceRuntime.java
+++ b/src/share/classes/com/sun/btrace/BTraceRuntime.java
@@ -2379,8 +2379,16 @@ public final class BTraceRuntime  {
                     return;
                 }
                 String path = loader.getResource("com/sun/btrace").toString();
-                path = path.substring(0, path.indexOf("!"));
-                path = path.substring("jar:".length(), path.lastIndexOf('/'));
+                int archSeparator = path.indexOf("!");
+                if (archSeparator != -1) {
+                    path = path.substring(0, archSeparator);
+                    path = path.substring("jar:".length(), path.lastIndexOf('/'));
+                } else {
+                    int buildSeparator = path.indexOf("/classes/");
+                    if (buildSeparator != -1) {
+                        path = path.substring(0, buildSeparator);
+                    }
+                }
                 String cpu = System.getProperty("os.arch");
                 if (cpu.equals("x86")) {
                     cpu = "i386";


### PR DESCRIPTION
Now, on Solaris the DTrace integration lib will be built using the original Makefile and placed to the correct folder to be picked up by the BTrace runtime.