### PR TITLE
use groovy .each instead of java8 .forEach

### DIFF
--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -39,7 +39,7 @@ task btracec(type: JavaExec) {
 compileJava.dependsOn btracec
 
 
-['BTraceBench', 'ProfilerBenchmarks', 'StatsdBenchmarks', 'StringOpBenchmarks'].forEach { className ->
+['BTraceBench', 'ProfilerBenchmarks', 'StatsdBenchmarks', 'StringOpBenchmarks'].each { className ->
   task(type: JavaExec, className) {
     group 'Verification'
     description "Run benchmark for class ${className}."


### PR DESCRIPTION
The name says it. I accidentally introduced a java8 `.forEach`. 
Today I learned that this will give you strange error messages when trying to build on a system where java7 is the default.