### PR TITLE
Adding the ability to trace native methods

### DIFF
--- a/src/share/classes/META-INF/agent-manifest.mf
+++ b/src/share/classes/META-INF/agent-manifest.mf
@@ -3,3 +3,4 @@ Agent-Class: com.sun.btrace.agent.Main
 Boot-Class-Path: btrace-boot.jar
 Can-Redefine-Classes: true
 Can-Retransform-Classes: true
+Can-Set-Native-Method-Prefix: true

--- a/src/share/classes/com/sun/btrace/agent/Client.java
+++ b/src/share/classes/com/sun/btrace/agent/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008-2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ import com.sun.btrace.org.objectweb.asm.Opcodes;
 import com.sun.btrace.runtime.ClassFilter;
 import com.sun.btrace.runtime.ClassRenamer;
 import com.sun.btrace.runtime.ClinitInjector;
+import com.sun.btrace.runtime.Constants;
 import com.sun.btrace.runtime.Instrumentor;
 import com.sun.btrace.runtime.InstrumentUtils;
 import com.sun.btrace.runtime.Location;
@@ -138,6 +139,7 @@ abstract class Client implements ClassFileTransformer, CommandListener {
         this.inst = inst;
     }
 
+    @Override
     public byte[] transform(
                 ClassLoader loader,
                 String cname,
@@ -194,6 +196,7 @@ abstract class Client implements ClassFileTransformer, CommandListener {
     void registerTransformer() {
         inst.addTransformer(clInitTransformer, false);
         inst.addTransformer(this, true);
+        inst.setNativeMethodPrefix(this, Constants.BTRACE_NATIVE_PREFIX);
     }
 
     void unregisterTransformer() {
@@ -239,6 +242,7 @@ abstract class Client implements ClassFileTransformer, CommandListener {
             errorExit(th);
             return null;
         }
+
         Main.dumpClass(className + "_orig", className + "_orig", btraceCode);
 
         this.filter = new ClassFilter(onMethods);

--- a/src/share/classes/com/sun/btrace/runtime/Constants.java
+++ b/src/share/classes/com/sun/btrace/runtime/Constants.java
@@ -48,6 +48,9 @@ public abstract class Constants {
     public static final String BTRACE_METHOD_PREFIX =
         "$btrace$";
 
+    public static final String BTRACE_NATIVE_PREFIX =
+        "$btrace$native$";
+
     public static final String JAVA_LANG_OBJECT =
         Type.getInternalName(Object.class);
     public static final String JAVA_LANG_THROWABLE =

--- a/src/share/classes/com/sun/btrace/runtime/InstrumentUtils.java
+++ b/src/share/classes/com/sun/btrace/runtime/InstrumentUtils.java
@@ -1,12 +1,12 @@
 /*
- * Copyright 2008-2010 Sun Microsystems, Inc.  All Rights Reserved.
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Sun designates this
+ * published by the Free Software Foundation.  Oracle designates this
  * particular file as subject to the "Classpath" exception as provided
- * by Sun in the LICENSE file that accompanied this code.
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -18,9 +18,9 @@
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
- * CA 95054 USA or visit www.sun.com if you need additional information or
- * have any questions.
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 package com.sun.btrace.runtime;
@@ -34,7 +34,7 @@ import static com.sun.btrace.runtime.Constants.JAVA_LANG_OBJECT;
 /**
  * @author A. Sundararajan
  */
-public class InstrumentUtils {
+public final class InstrumentUtils {
     private static class BTraceClassWriter extends ClassWriter {
         /**
          * This delegating classloader allows to check whether a particular
@@ -145,5 +145,9 @@ public class InstrumentUtils {
                               new BTraceClassWriter(flags);
 
         return cw;
+    }
+
+    public static final String getActionPrefix(String className) {
+        return Constants.BTRACE_METHOD_PREFIX + className.replace('/', '$') + "$";
     }
 }

--- a/src/test/com/sun/btrace/runtime/InstrumentorTest.java
+++ b/src/test/com/sun/btrace/runtime/InstrumentorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1514,6 +1514,96 @@ public class InstrumentorTest extends InstrumentorTestBase {
             "INVOKESTATIC com/sun/btrace/BTraceRuntime.handleException (Ljava/lang/Throwable;)V\n" +
             "INVOKESTATIC com/sun/btrace/BTraceRuntime.leave ()V\n" +
             "RETURN"
+        );
+    }
+
+    @Test
+    public void nativeWithReturnTracingTest() throws Exception {
+        loadTargetClass("OnMethodTest");
+        transform("onmethod/NativeWithReturn", false);
+
+        checkTransformation(
+            "// access flags 0x1\n" +
+            "public nativeWithReturn(ILjava/lang/String;[J[Ljava/lang/Object;)J\n" +
+            "ALOAD 0\n" +
+            "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$NativeWithReturn$nMethod (Ljava/lang/Object;)V\n" +
+            "ALOAD 0\n" +
+            "ILOAD 1\n" +
+            "ALOAD 2\n" +
+            "ALOAD 3\n" +
+            "ALOAD 4\n" +
+            "INVOKESPECIAL resources/OnMethodTest.$btrace$native$nativeWithReturn (ILjava/lang/String;[J[Ljava/lang/Object;)J\n" +
+            "LRETURN\n" +
+            "MAXSTACK = 5\n" +
+            "MAXLOCALS = 5\n" +
+            "\n" +
+            "public native $btrace$native$nativeWithReturn(ILjava/lang/String;[J[Ljava/lang/Object;)J\n" +
+            "\n" +
+            "// access flags 0xA\n" +
+            "private static $btrace$traces$onmethod$NativeWithReturn$nMethod(Ljava/lang/Object;)V\n" +
+            "@Lcom/sun/btrace/annotations/OnMethod;(clazz=\"/.*\\\\.OnMethodTest/\", method=\"nativeWithReturn\")\n" +
+            "@Lcom/sun/btrace/annotations/Self;() // parameter 0\n" +
+            "TRYCATCHBLOCK L0 L1 L1 java/lang/Throwable\n" +
+            "GETSTATIC traces/onmethod/NativeWithReturn.runtime : Lcom/sun/btrace/BTraceRuntime;\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.enter (Lcom/sun/btrace/BTraceRuntime;)Z\n" +
+            "IFNE L0\n" +
+            "RETURN\n" +
+            "L0\n" +
+            "LDC \"args\"\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceUtils.println (Ljava/lang/Object;)V\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.leave ()V\n" +
+            "RETURN\n" +
+            "L1\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.handleException (Ljava/lang/Throwable;)V\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.leave ()V\n" +
+            "RETURN\n" +
+            "MAXSTACK = 1\n" +
+            "MAXLOCALS = 1"
+        );
+    }
+
+    @Test
+    public void nativeWithoutReturnTracingTest() throws Exception {
+        loadTargetClass("OnMethodTest");
+        transform("onmethod/NativeWithoutReturn", false);
+
+        checkTransformation(
+            "// access flags 0x1\n" +
+            "public nativeWithoutReturn(ILjava/lang/String;[J[Ljava/lang/Object;)V\n" +
+            "ALOAD 0\n" +
+            "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$NativeWithoutReturn$nMethod (Ljava/lang/Object;)V\n" +
+            "ALOAD 0\n" +
+            "ILOAD 1\n" +
+            "ALOAD 2\n" +
+            "ALOAD 3\n" +
+            "ALOAD 4\n" +
+            "INVOKESPECIAL resources/OnMethodTest.$btrace$native$nativeWithoutReturn (ILjava/lang/String;[J[Ljava/lang/Object;)V\n" +
+            "RETURN\n" +
+            "MAXSTACK = 5\n" +
+            "MAXLOCALS = 5\n" +
+            "\n" +
+            "public native $btrace$native$nativeWithoutReturn(ILjava/lang/String;[J[Ljava/lang/Object;)V\n" +
+            "\n" +
+            "// access flags 0xA\n" +
+            "private static $btrace$traces$onmethod$NativeWithoutReturn$nMethod(Ljava/lang/Object;)V\n" +
+            "@Lcom/sun/btrace/annotations/OnMethod;(clazz=\"/.*\\\\.OnMethodTest/\", method=\"nativeWithoutReturn\")\n" +
+            "@Lcom/sun/btrace/annotations/Self;() // parameter 0\n" +
+            "TRYCATCHBLOCK L0 L1 L1 java/lang/Throwable\n" +
+            "GETSTATIC traces/onmethod/NativeWithoutReturn.runtime : Lcom/sun/btrace/BTraceRuntime;\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.enter (Lcom/sun/btrace/BTraceRuntime;)Z\n" +
+            "IFNE L0\n" +
+            "RETURN\n" +
+            "L0\n" +
+            "LDC \"args\"\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceUtils.println (Ljava/lang/Object;)V\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.leave ()V\n" +
+            "RETURN\n" +
+            "L1\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.handleException (Ljava/lang/Throwable;)V\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.leave ()V\n" +
+            "RETURN\n" +
+            "MAXSTACK = 1\n" +
+            "MAXLOCALS = 1"
         );
     }
 }

--- a/src/test/resources/OnMethodTest.java
+++ b/src/test/resources/OnMethodTest.java
@@ -1,12 +1,12 @@
 /*
- * Copyright 2008-2010 Sun Microsystems, Inc.  All Rights Reserved.
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Sun designates this
+ * published by the Free Software Foundation.  Oracle designates this
  * particular file as subject to the "Classpath" exception as provided
- * by Sun in the LICENSE file that accompanied this code.
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -18,9 +18,9 @@
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
- * CA 95054 USA or visit www.sun.com if you need additional information or
- * have any questions.
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 package resources;
@@ -133,4 +133,7 @@ public class OnMethodTest {
             return -1L;
         }
     }
+
+    public native long nativeWithReturn(int a, String b, long[] c, Object[] d);
+    public native void nativeWithoutReturn(int a, String b, long[] c, Object[] d);
 }

--- a/src/test/support/RuntimeTest.java
+++ b/src/test/support/RuntimeTest.java
@@ -85,16 +85,17 @@ abstract public class RuntimeTest {
         }
         btraceExtPath = btraceExtPath + File.pathSeparator + toolsjar;
         java = System.getProperty("java.home").replace("/jre", "");
+        System.err.println("*** JAVA = " + java);
     }
 
     /**
      * Display the otput from the test application
      */
-    protected boolean debugTestApp = false;
+    protected boolean debugTestApp = true;
     /**
      * Run BTrace in debug mode
      */
-    protected boolean debugBTrace = false;
+    protected boolean debugBTrace = true;
     /**
      * Run BTrace in unsafe mode
      */
@@ -105,8 +106,8 @@ abstract public class RuntimeTest {
     protected long timeout = 10000L;
 
     protected void reset() {
-        debugTestApp = false;
-        debugBTrace = false;
+        debugTestApp = true;
+        debugBTrace = true;
         isUnsafe = false;
         timeout = 10000L;
     }

--- a/src/test/support/RuntimeTest.java
+++ b/src/test/support/RuntimeTest.java
@@ -85,17 +85,16 @@ abstract public class RuntimeTest {
         }
         btraceExtPath = btraceExtPath + File.pathSeparator + toolsjar;
         java = System.getProperty("java.home").replace("/jre", "");
-        System.err.println("*** JAVA = " + java);
     }
 
     /**
      * Display the otput from the test application
      */
-    protected boolean debugTestApp = true;
+    protected boolean debugTestApp = false;
     /**
      * Run BTrace in debug mode
      */
-    protected boolean debugBTrace = true;
+    protected boolean debugBTrace = false;
     /**
      * Run BTrace in unsafe mode
      */
@@ -106,8 +105,8 @@ abstract public class RuntimeTest {
     protected long timeout = 10000L;
 
     protected void reset() {
-        debugTestApp = true;
-        debugBTrace = true;
+        debugTestApp = false;
+        debugBTrace = false;
         isUnsafe = false;
         timeout = 10000L;
     }

--- a/src/test/traces/onmethod/NativeWithReturn.java
+++ b/src/test/traces/onmethod/NativeWithReturn.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package traces.onmethod;
+
+import com.sun.btrace.annotations.BTrace;
+import com.sun.btrace.annotations.OnMethod;
+import com.sun.btrace.annotations.Self;
+import static com.sun.btrace.BTraceUtils.*;
+
+/**
+ *
+ * @author Jaroslav Bachorik
+ */
+@BTrace
+public class NativeWithReturn {
+    @OnMethod(clazz="/.*\\.OnMethodTest/", method="nativeWithReturn")
+    public static void nMethod(@Self Object self) {
+        println("args");
+    }
+}

--- a/src/test/traces/onmethod/NativeWithoutReturn.java
+++ b/src/test/traces/onmethod/NativeWithoutReturn.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package traces.onmethod;
+
+import com.sun.btrace.annotations.BTrace;
+import com.sun.btrace.annotations.OnMethod;
+import com.sun.btrace.annotations.Self;
+import static com.sun.btrace.BTraceUtils.*;
+
+/**
+ *
+ * @author Jaroslav Bachorik
+ */
+@BTrace
+public class NativeWithoutReturn {
+    @OnMethod(clazz="/.*\\.OnMethodTest/", method="nativeWithoutReturn")
+    public static void nMethod(@Self Object self) {
+        println("args");
+    }
+}


### PR DESCRIPTION
Resolves #115 

With this patch it is possible to trace native methods. There is no difference in usage to the non-native methods.

Eg. the following trace scripts will work on all methods of the __Test__ class regardless of whether they are native or not.

```
@BTrace                                                                                                                                                                                                       
public class NativeTracker {                                                                                                                                                                           
    @OnMethod(clazz="Test", method="/.*/")                                                                                                                                                         
    public static void nativeMethod(@Self Object self, @ProbeClassName String pcn, ProbeMethodName String pmn, String msg) {                                                                                      
        println("entering: " + pcn + "." + pmn);                                                                                                                                                      
        println("msg = " + msg);                                                                                                                                                                              
    }                                                                                                                                                                                                         
}  
```