### PR TITLE
Fixes #131. Modifying the Preprocessor to work well with the augmente…

### DIFF
--- a/src/share/classes/com/sun/btrace/compiler/Verifier.java
+++ b/src/share/classes/com/sun/btrace/compiler/Verifier.java
@@ -67,7 +67,7 @@ import com.sun.tools.javac.util.Context;
  * @author A. Sundararajan
  */
 @SupportedAnnotationTypes("*")
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
+@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class Verifier extends AbstractProcessor
                             implements TaskListener {
     private final List<String> classNames =

--- a/src/share/classes/com/sun/btrace/compiler/VerifierVisitor.java
+++ b/src/share/classes/com/sun/btrace/compiler/VerifierVisitor.java
@@ -50,7 +50,6 @@ import java.util.EnumSet;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 
@@ -75,7 +74,7 @@ public class VerifierVisitor extends TreeScanner<Boolean, Void> {
 
     public VerifierVisitor(Verifier verifier, Element clzElement) {
         this.verifier = verifier;
-        Collection<ExecutableElement> shared = new ArrayList<ExecutableElement>();
+        Collection<ExecutableElement> shared = new ArrayList<>();
         for(Element e : clzElement.getEnclosedElements()) {
             if (e.getKind() == ElementKind.METHOD && e.getModifiers().containsAll(EnumSet.of(Modifier.STATIC, Modifier.PRIVATE))) {
                 shared.add((ExecutableElement)e);

--- a/src/share/classes/com/sun/btrace/runtime/InstrumentUtils.java
+++ b/src/share/classes/com/sun/btrace/runtime/InstrumentUtils.java
@@ -1,12 +1,12 @@
 /*
- * Copyright 2008-2010 Sun Microsystems, Inc.  All Rights Reserved.
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Sun designates this
+ * published by the Free Software Foundation.  Oracle designates this
  * particular file as subject to the "Classpath" exception as provided
- * by Sun in the LICENSE file that accompanied this code.
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -18,9 +18,9 @@
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
- * CA 95054 USA or visit www.sun.com if you need additional information or
- * have any questions.
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 package com.sun.btrace.runtime;

--- a/src/share/classes/com/sun/btrace/runtime/Instrumentor.java
+++ b/src/share/classes/com/sun/btrace/runtime/Instrumentor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -567,7 +567,9 @@ public class Instrumentor extends ClassVisitor {
                                     // will also retrieve the call args and the return value from the backup variables
                                     injectBtrace(vr, method, calledMethodArgs, returnType);
                                     if (withReturn) {
-                                        asm.loadLocal(returnType, returnVarIndex); // restore the return value
+                                        if (Type.getReturnType(om.getTargetDescriptor()).getSort() == Type.VOID) {
+                                            asm.loadLocal(returnType, returnVarIndex); // restore the return value
+                                        }
                                     }
                                     MethodTrackingExpander.ELSE.insert(mv);
                                     if (this.parent == null) {
@@ -1194,7 +1196,9 @@ public class Instrumentor extends ClassVisitor {
 
                         try {
                             if (om.getReturnParameter() != -1) {
-                                asm.dupReturnValue(retOpCode);
+                                if (Type.getReturnType(om.getTargetDescriptor()).getSort() == Type.VOID) {
+                                    asm.dupReturnValue(retOpCode);
+                                }
                                 retValIndex = storeNewLocal(getReturnType());
                             }
 

--- a/src/share/classes/com/sun/btrace/runtime/OnMethod.java
+++ b/src/share/classes/com/sun/btrace/runtime/OnMethod.java
@@ -1,12 +1,12 @@
 /*
- * Copyright 2008-2010 Sun Microsystems, Inc.  All Rights Reserved.
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Sun designates this
+ * published by the Free Software Foundation.  Oracle designates this
  * particular file as subject to the "Classpath" exception as provided
- * by Sun in the LICENSE file that accompanied this code.
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -18,9 +18,9 @@
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
- * CA 95054 USA or visit www.sun.com if you need additional information or
- * have any questions.
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 package com.sun.btrace.runtime;

--- a/src/share/classes/com/sun/btrace/runtime/OnMethodsAcceptor.java
+++ b/src/share/classes/com/sun/btrace/runtime/OnMethodsAcceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,26 +22,14 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+package com.sun.btrace.runtime;
 
-package traces.onmethod;
-
-import com.sun.btrace.annotations.BTrace;
-import com.sun.btrace.annotations.Kind;
-import com.sun.btrace.annotations.Location;
-import com.sun.btrace.annotations.OnMethod;
-import com.sun.btrace.annotations.Return;
-import com.sun.btrace.annotations.Where;
-import static com.sun.btrace.BTraceUtils.*;
+import java.util.List;
 
 /**
- *
+ * A temporary solution for Preprocessor/Verifier onmethods list sharing
  * @author Jaroslav Bachorik
  */
-@BTrace
-public class MethodCallReturn {
-    @OnMethod(clazz="/.*\\.OnMethodTest/", method="callTopLevel",
-              location=@Location(value=Kind.CALL, clazz="/.*\\.OnMethodTest/", method="callTarget", where=Where.AFTER))
-    public static void args(@Return long retVal, String a, long b) {
-        println("args");
-    }
+interface OnMethodsAcceptor {
+    void accept(List<OnMethod> onMethods);
 }

--- a/src/share/classes/com/sun/btrace/runtime/Preprocessor.java
+++ b/src/share/classes/com/sun/btrace/runtime/Preprocessor.java
@@ -57,10 +57,13 @@ import com.sun.btrace.org.objectweb.asm.tree.TryCatchBlockNode;
 import com.sun.btrace.org.objectweb.asm.tree.TypeInsnNode;
 import com.sun.btrace.org.objectweb.asm.tree.VarInsnNode;
 import com.sun.btrace.services.api.Service;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -93,7 +96,7 @@ import java.util.Set;
  * @author A. Sundararajan
  * @author J. Bachorik (Tree API rewrite)
  */
-public class Preprocessor extends ClassVisitor {
+public class Preprocessor extends ClassVisitor implements OnMethodsAcceptor {
     private static class LocalVarGenerator {
         private int offset = 0;
 
@@ -154,9 +157,16 @@ public class Preprocessor extends ClassVisitor {
     private final Map<String, AnnotationNode> injectedFlds = new HashMap<>();
     private final Map<String, Integer> serviceLocals = new HashMap<>();
 
+    private List<OnMethod> onMethods = new ArrayList<>();
+
     public Preprocessor(ClassVisitor cv) {
         super(Opcodes.ASM5, cv);
         cn = new ClassNode(Opcodes.ASM5);
+    }
+
+    @Override
+    public void accept(List<OnMethod> onMethods) {
+        this.onMethods = onMethods;
     }
 
     @Override
@@ -223,6 +233,7 @@ public class Preprocessor extends ClassVisitor {
     private void preprocessMethod(MethodNode mn) {
         // !!! The order of execution is important here !!!
         LocalVarGenerator lvg = new LocalVarGenerator(mn);
+        checkAugmentedReturn(mn, lvg);
         scanMethodInstructions(mn, lvg);
         addBTraceErrorHandler(mn, lvg);
         addBTraceRuntimeEnter(mn, lvg);
@@ -333,7 +344,7 @@ public class Preprocessor extends ClassVisitor {
         Object initVal = fn.value;
         fn.value = null;
         fn.access |= Opcodes.ACC_FINAL;
-        
+
         InsnList l = clinit.instructions;
 
         MethodInsnNode boxNode;
@@ -392,6 +403,36 @@ public class Preprocessor extends ClassVisitor {
            default: {
                l.insert(new InsnNode(Opcodes.ACONST_NULL));
            }
+        }
+    }
+
+    private void checkAugmentedReturn(MethodNode mn, LocalVarGenerator lvg) {
+        Type retType = Type.getReturnType(mn.desc);
+        if (retType.getSort() != Type.VOID) {
+            if (getReturnMethodParameter(mn) == Integer.MIN_VALUE) {
+                // insert the method return parameter
+                String oldDesc = mn.desc;
+                Type[] args = Type.getArgumentTypes(mn.desc);
+                args = Arrays.copyOf(args, args.length + 1);
+                args[args.length - 1] = retType;
+
+                List<AnnotationNode> annots = new LinkedList<>();
+                AnnotationNode an = new AnnotationNode(Type.getDescriptor(Return.class));
+                annots.add(an);
+                mn.visibleParameterAnnotations = mn.visibleParameterAnnotations != null ?
+                                                    Arrays.copyOf(mn.visibleParameterAnnotations, args.length) :
+                                                    new List[args.length];
+                mn.visibleParameterAnnotations[args.length - 1] = annots;
+                mn.desc = Type.getMethodDescriptor(retType, args);
+
+                for(OnMethod om : onMethods) {
+                    if (om.getTargetName().equals(mn.name) && om.getTargetDescriptor().equals(oldDesc)) {
+                        om.setReturnParameter(getReturnMethodParameter(mn));
+                        om.setTargetDescriptor(mn.desc);
+                        break;
+                    }
+                }
+            }
         }
     }
 
@@ -1073,5 +1114,25 @@ public class Preprocessor extends ClassVisitor {
             );
         }
         return null;
+    }
+
+    private int getReturnMethodParameter(MethodNode mn) {
+        if (mn.visibleParameterAnnotations != null) {
+            int idx = 0;
+            Type[] args = Type.getArgumentTypes(mn.desc);
+            for(int i=0;i<mn.visibleParameterAnnotations.length;i++) {
+                List paList = (List)mn.visibleParameterAnnotations[i];
+                if (paList != null) {
+                    for(Object anObj : paList) {
+                        AnnotationNode an = (AnnotationNode)anObj;
+                        if (an.desc.equals(Type.getDescriptor(Return.class))) {
+                            return i;
+                        }
+                    }
+                }
+                idx += args[i].getSize();
+            }
+        }
+        return Integer.MIN_VALUE;
     }
 }

--- a/src/share/classes/com/sun/btrace/runtime/Verifier.java
+++ b/src/share/classes/com/sun/btrace/runtime/Verifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,15 +76,20 @@ public class Verifier extends ClassVisitor {
     private boolean unsafeScript, unsafeAllowed;
     private CycleDetector cycleDetector;
 
-    protected final Set<String> injectedFields = new HashSet<String>();
+    protected final Set<String> injectedFields = new HashSet<>();
 
     public Verifier(ClassVisitor cv, boolean unsafe) {
         super(Opcodes.ASM5, cv);
         this.unsafeAllowed = unsafe;
-        onMethods = new ArrayList<OnMethod>();
-        onProbes = new ArrayList<OnProbe>();
+        this.onMethods = new ArrayList<>();
+        onProbes = new ArrayList<>();
         cycleDetector = new CycleDetector();
+
+        if (cv instanceof OnMethodsAcceptor) {
+            ((OnMethodsAcceptor)cv).accept(onMethods);
+        }
     }
+
 
     public Verifier(ClassVisitor cv) {
         this(cv, false);

--- a/src/test/com/sun/btrace/runtime/InstrumentorTest.java
+++ b/src/test/com/sun/btrace/runtime/InstrumentorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -432,6 +432,92 @@ public class InstrumentorTest extends InstrumentorTestBase {
         loadTargetClass("OnMethodTest");
         transform("onmethod/ArgsReturn");
         checkTransformation("DUP2\nLSTORE 6\nALOAD 0\nLLOAD 6\nALOAD 1\nLLOAD 2\nALOAD 4\nALOAD 5\nINVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$ArgsReturn$args (Ljava/lang/Object;JLjava/lang/String;J[Ljava/lang/String;[I)V");
+    }
+
+    @Test
+    public void methodEntryArgsReturnAugmented() throws Exception {
+        loadTargetClass("OnMethodTest");
+        transform("onmethod/ArgsReturnAugmented", true);
+        checkTransformation("LSTORE 6\n" +
+            "ALOAD 0\n" +
+            "ALOAD 1\n" +
+            "LLOAD 2\n" +
+            "ALOAD 4\n" +
+            "ALOAD 5\n" +
+            "LLOAD 6\n" +
+            "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$ArgsReturnAugmented$args (Ljava/lang/Object;Ljava/lang/String;J[Ljava/lang/String;[IJ)J\n" +
+            "MAXSTACK = 8\n" +
+            "MAXLOCALS = 8\n" +
+            "\n" +
+            "// access flags 0xA\n" +
+            "private static $btrace$traces$onmethod$ArgsReturnAugmented$args(Ljava/lang/Object;Ljava/lang/String;J[Ljava/lang/String;[IJ)J\n" +
+            "@Lcom/sun/btrace/annotations/OnMethod;(clazz=\"/.*\\\\.OnMethodTest/\", method=\"args\", location=@Lcom/sun/btrace/annotations/Location;(value=Lcom/sun/btrace/annotations/Kind;.RETURN))\n" +
+            "@Lcom/sun/btrace/annotations/Self;() // parameter 0\n" +
+            "@Lcom/sun/btrace/annotations/Return;() // parameter 5\n" +
+            "TRYCATCHBLOCK L0 L1 L1 java/lang/Throwable\n" +
+            "GETSTATIC traces/onmethod/ArgsReturnAugmented.runtime : Lcom/sun/btrace/BTraceRuntime;\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.enter (Lcom/sun/btrace/BTraceRuntime;)Z\n" +
+            "IFNE L0\n" +
+            "LLOAD 6\n" +
+            "LRETURN\n" +
+            "L0\n" +
+            "LDC \"args\"\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceUtils.println (Ljava/lang/Object;)V\n" +
+            "LCONST_1\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.leave ()V\n" +
+            "LRETURN\n" +
+            "L1\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.handleException (Ljava/lang/Throwable;)V\n" +
+            "LLOAD 6\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.leave ()V\n" +
+            "LRETURN\n" +
+            "MAXSTACK = 2\n" +
+            "MAXLOCALS = 8"
+        );
+    }
+
+    @Test
+    public void methodEntryArgsReturnAugmented1() throws Exception {
+        loadTargetClass("OnMethodTest");
+        transform("onmethod/ArgsReturnAugmented1", true);
+        checkTransformation("LSTORE 6\n" +
+            "ALOAD 0\n" +
+            "LLOAD 6\n" +
+            "ALOAD 1\n" +
+            "LLOAD 2\n" +
+            "ALOAD 4\n" +
+            "ALOAD 5\n" +
+            "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$ArgsReturnAugmented1$args (Ljava/lang/Object;JLjava/lang/String;J[Ljava/lang/String;[I)J\n" +
+            "MAXSTACK = 8\n" +
+            "MAXLOCALS = 8\n" +
+            "\n" +
+            "// access flags 0xA\n" +
+            "private static $btrace$traces$onmethod$ArgsReturnAugmented1$args(Ljava/lang/Object;JLjava/lang/String;J[Ljava/lang/String;[I)J\n" +
+            "@Lcom/sun/btrace/annotations/OnMethod;(clazz=\"/.*\\\\.OnMethodTest/\", method=\"args\", location=@Lcom/sun/btrace/annotations/Location;(value=Lcom/sun/btrace/annotations/Kind;.RETURN))\n" +
+            "@Lcom/sun/btrace/annotations/Self;() // parameter 0\n" +
+            "@Lcom/sun/btrace/annotations/Return;() // parameter 1\n" +
+            "TRYCATCHBLOCK L0 L1 L1 java/lang/Throwable\n" +
+            "GETSTATIC traces/onmethod/ArgsReturnAugmented1.runtime : Lcom/sun/btrace/BTraceRuntime;\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.enter (Lcom/sun/btrace/BTraceRuntime;)Z\n" +
+            "IFNE L0\n" +
+            "LLOAD 1\n" +
+            "LRETURN\n" +
+            "L0\n" +
+            "LDC \"args\"\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceUtils.println (Ljava/lang/Object;)V\n" +
+            "LLOAD 1\n" +
+            "LCONST_1\n" +
+            "LADD\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.leave ()V\n" +
+            "LRETURN\n" +
+            "L1\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.handleException (Ljava/lang/Throwable;)V\n" +
+            "LLOAD 1\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.leave ()V\n" +
+            "LRETURN\n" +
+            "MAXSTACK = 4\n" +
+            "MAXLOCALS = 8"
+        );
     }
 
     @Test
@@ -909,6 +995,96 @@ public class InstrumentorTest extends InstrumentorTestBase {
                 + "LSTORE 8\nLLOAD 8\nALOAD 6\nLLOAD 4\n"
                 + "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$MethodCallReturn$args (JLjava/lang/String;J)V\n"
                 + "LLOAD 8");
+    }
+
+    @Test
+    public void methodCallReturnAugmented() throws Exception {
+        loadTargetClass("OnMethodTest");
+        transform("onmethod/MethodCallReturnAugmented", true);
+
+        checkTransformation("LSTORE 4\n" +
+            "ASTORE 6\n" +
+            "ASTORE 7\n" +
+            "ALOAD 7\n" +
+            "ALOAD 6\n" +
+            "LLOAD 4\n" +
+            "LSTORE 8\n" +
+            "ALOAD 6\n" +
+            "LLOAD 4\n" +
+            "LLOAD 8\n" +
+            "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$MethodCallReturnAugmented$args (Ljava/lang/String;JJ)J\n" +
+            "MAXLOCALS = 10\n" +
+            "\n" +
+            "// access flags 0xA\n" +
+            "private static $btrace$traces$onmethod$MethodCallReturnAugmented$args(Ljava/lang/String;JJ)J\n" +
+            "@Lcom/sun/btrace/annotations/OnMethod;(clazz=\"/.*\\\\.OnMethodTest/\", method=\"callTopLevel\", location=@Lcom/sun/btrace/annotations/Location;(value=Lcom/sun/btrace/annotations/Kind;.CALL, clazz=\"/.*\\\\.OnMethodTest/\", method=\"callTarget\", where=Lcom/sun/btrace/annotations/Where;.AFTER))\n" +
+            "@Lcom/sun/btrace/annotations/Return;() // parameter 2\n" +
+            "TRYCATCHBLOCK L0 L1 L1 java/lang/Throwable\n" +
+            "GETSTATIC traces/onmethod/MethodCallReturnAugmented.runtime : Lcom/sun/btrace/BTraceRuntime;\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.enter (Lcom/sun/btrace/BTraceRuntime;)Z\n" +
+            "IFNE L0\n" +
+            "LLOAD 3\n" +
+            "LRETURN\n" +
+            "L0\n" +
+            "LDC \"args\"\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceUtils.println (Ljava/lang/Object;)V\n" +
+            "LCONST_1\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.leave ()V\n" +
+            "LRETURN\n" +
+            "L1\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.handleException (Ljava/lang/Throwable;)V\n" +
+            "LLOAD 3\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.leave ()V\n" +
+            "LRETURN\n" +
+            "MAXSTACK = 2\n" +
+            "MAXLOCALS = 5"
+        );
+    }
+
+    @Test
+    public void methodCallReturnAugmented1() throws Exception {
+        loadTargetClass("OnMethodTest");
+        transform("onmethod/MethodCallReturnAugmented1", true);
+
+        checkTransformation("LSTORE 4\n" +
+            "ASTORE 6\n" +
+            "ASTORE 7\n" +
+            "ALOAD 7\n" +
+            "ALOAD 6\n" +
+            "LLOAD 4\n" +
+            "LSTORE 8\n" +
+            "LLOAD 8\n" +
+            "ALOAD 6\n" +
+            "LLOAD 4\n" +
+            "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$MethodCallReturnAugmented1$args (JLjava/lang/String;J)J\n" +
+            "MAXLOCALS = 10\n" +
+            "\n" +
+            "// access flags 0xA\n" +
+            "private static $btrace$traces$onmethod$MethodCallReturnAugmented1$args(JLjava/lang/String;J)J\n" +
+            "@Lcom/sun/btrace/annotations/OnMethod;(clazz=\"/.*\\\\.OnMethodTest/\", method=\"callTopLevel\", location=@Lcom/sun/btrace/annotations/Location;(value=Lcom/sun/btrace/annotations/Kind;.CALL, clazz=\"/.*\\\\.OnMethodTest/\", method=\"callTarget\", where=Lcom/sun/btrace/annotations/Where;.AFTER))\n" +
+            "@Lcom/sun/btrace/annotations/Return;() // parameter 0\n" +
+            "TRYCATCHBLOCK L0 L1 L1 java/lang/Throwable\n" +
+            "GETSTATIC traces/onmethod/MethodCallReturnAugmented1.runtime : Lcom/sun/btrace/BTraceRuntime;\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.enter (Lcom/sun/btrace/BTraceRuntime;)Z\n" +
+            "IFNE L0\n" +
+            "LLOAD 0\n" +
+            "LRETURN\n" +
+            "L0\n" +
+            "LDC \"args\"\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceUtils.println (Ljava/lang/Object;)V\n" +
+            "LLOAD 0\n" +
+            "LCONST_1\n" +
+            "LADD\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.leave ()V\n" +
+            "LRETURN\n" +
+            "L1\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.handleException (Ljava/lang/Throwable;)V\n" +
+            "LLOAD 0\n" +
+            "INVOKESTATIC com/sun/btrace/BTraceRuntime.leave ()V\n" +
+            "LRETURN\n" +
+            "MAXSTACK = 4\n" +
+            "MAXLOCALS = 5"
+        );
     }
 
     @Test

--- a/src/test/resources/OnMethodTest.java
+++ b/src/test/resources/OnMethodTest.java
@@ -1,12 +1,12 @@
 /*
- * Copyright 2008-2010 Sun Microsystems, Inc.  All Rights Reserved.
+ * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Sun designates this
+ * published by the Free Software Foundation.  Oracle designates this
  * particular file as subject to the "Classpath" exception as provided
- * by Sun in the LICENSE file that accompanied this code.
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -18,9 +18,9 @@
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
- * CA 95054 USA or visit www.sun.com if you need additional information or
- * have any questions.
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 package resources;

--- a/src/test/traces/onmethod/ArgsReturn.java
+++ b/src/test/traces/onmethod/ArgsReturn.java
@@ -1,12 +1,12 @@
 /*
- * Copyright 2008-2010 Sun Microsystems, Inc.  All Rights Reserved.
+ * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Sun designates this
+ * published by the Free Software Foundation.  Oracle designates this
  * particular file as subject to the "Classpath" exception as provided
- * by Sun in the LICENSE file that accompanied this code.
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -18,9 +18,9 @@
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
- * CA 95054 USA or visit www.sun.com if you need additional information or
- * have any questions.
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 package traces.onmethod;

--- a/src/test/traces/onmethod/ArgsReturnAugmented.java
+++ b/src/test/traces/onmethod/ArgsReturnAugmented.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,19 +29,18 @@ import com.sun.btrace.annotations.BTrace;
 import com.sun.btrace.annotations.Kind;
 import com.sun.btrace.annotations.Location;
 import com.sun.btrace.annotations.OnMethod;
-import com.sun.btrace.annotations.Return;
-import com.sun.btrace.annotations.Where;
+import com.sun.btrace.annotations.Self;
 import static com.sun.btrace.BTraceUtils.*;
 
 /**
  *
  * @author Jaroslav Bachorik
  */
-@BTrace
-public class MethodCallReturn {
-    @OnMethod(clazz="/.*\\.OnMethodTest/", method="callTopLevel",
-              location=@Location(value=Kind.CALL, clazz="/.*\\.OnMethodTest/", method="callTarget", where=Where.AFTER))
-    public static void args(@Return long retVal, String a, long b) {
+@BTrace(unsafe = true)
+public class ArgsReturnAugmented {
+    @OnMethod(clazz="/.*\\.OnMethodTest/", method="args", location=@Location(value=Kind.RETURN))
+    public static long args(@Self Object self, String a, long b, String[] c, int[] d) {
         println("args");
+        return 1;
     }
 }

--- a/src/test/traces/onmethod/ArgsReturnAugmented1.java
+++ b/src/test/traces/onmethod/ArgsReturnAugmented1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,26 +22,25 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
 package traces.onmethod;
 
 import com.sun.btrace.annotations.BTrace;
 import com.sun.btrace.annotations.Kind;
 import com.sun.btrace.annotations.Location;
 import com.sun.btrace.annotations.OnMethod;
-import com.sun.btrace.annotations.Return;
-import com.sun.btrace.annotations.Where;
+import com.sun.btrace.annotations.Self;
 import static com.sun.btrace.BTraceUtils.*;
+import com.sun.btrace.annotations.Return;
 
 /**
  *
  * @author Jaroslav Bachorik
  */
-@BTrace
-public class MethodCallReturn {
-    @OnMethod(clazz="/.*\\.OnMethodTest/", method="callTopLevel",
-              location=@Location(value=Kind.CALL, clazz="/.*\\.OnMethodTest/", method="callTarget", where=Where.AFTER))
-    public static void args(@Return long retVal, String a, long b) {
+@BTrace(unsafe = true)
+public class ArgsReturnAugmented1 {
+    @OnMethod(clazz="/.*\\.OnMethodTest/", method="args", location=@Location(value=Kind.RETURN))
+    public static long args(@Self Object self, @Return long ret, String a, long b, String[] c, int[] d) {
         println("args");
+        return ret + 1;
     }
 }

--- a/src/test/traces/onmethod/MethodCallReturnAugmented.java
+++ b/src/test/traces/onmethod/MethodCallReturnAugmented.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import com.sun.btrace.annotations.BTrace;
 import com.sun.btrace.annotations.Kind;
 import com.sun.btrace.annotations.Location;
 import com.sun.btrace.annotations.OnMethod;
-import com.sun.btrace.annotations.Return;
 import com.sun.btrace.annotations.Where;
 import static com.sun.btrace.BTraceUtils.*;
 
@@ -37,11 +36,12 @@ import static com.sun.btrace.BTraceUtils.*;
  *
  * @author Jaroslav Bachorik
  */
-@BTrace
-public class MethodCallReturn {
+@BTrace(unsafe = true)
+public class MethodCallReturnAugmented {
     @OnMethod(clazz="/.*\\.OnMethodTest/", method="callTopLevel",
               location=@Location(value=Kind.CALL, clazz="/.*\\.OnMethodTest/", method="callTarget", where=Where.AFTER))
-    public static void args(@Return long retVal, String a, long b) {
+    public static long args(String a, long b) {
         println("args");
+        return 1;
     }
 }

--- a/src/test/traces/onmethod/MethodCallReturnAugmented1.java
+++ b/src/test/traces/onmethod/MethodCallReturnAugmented1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,11 +37,12 @@ import static com.sun.btrace.BTraceUtils.*;
  *
  * @author Jaroslav Bachorik
  */
-@BTrace
-public class MethodCallReturn {
+@BTrace(unsafe = true)
+public class MethodCallReturnAugmented1 {
     @OnMethod(clazz="/.*\\.OnMethodTest/", method="callTopLevel",
               location=@Location(value=Kind.CALL, clazz="/.*\\.OnMethodTest/", method="callTarget", where=Where.AFTER))
-    public static void args(@Return long retVal, String a, long b) {
+    public static long args(@Return long retVal, String a, long b) {
         println("args");
+        return retVal + 1;
     }
 }


### PR DESCRIPTION
Sometimes it might be useful to augment the return value captured in `location=@Location(Kind.RETURN)` or `location=@Location(Kind.CALL)` handlers.

Eg. the following piece of code would put a cap on the value that could be returned by the intercepted method.

```
@BTrace(unsafe = true)
public class ArgsReturnAugmented {
    @OnMethod(clazz="TestClass", method="testMethod", location=@Location(value=Kind.RETURN))
    public static long args(@Self Object self, @Return long ret, String a, long b, String[] c, int[] d) {
        println("args");
        return ret > 100 ? 100 : ret;
    }
}
```

Since this functionality can bring instability to the traced application it is limited to the __unsafe__ mode only.