### PR TITLE
Run the client handling code asynchronously only when used from the GF3 Flashlight

### DIFF
--- a/src/share/classes/com/sun/btrace/agent/Main.java
+++ b/src/share/classes/com/sun/btrace/agent/Main.java
@@ -114,13 +114,6 @@ public final class Main {
             Main.inst = inst;
         }
 
-        Class[] classes = inst.getAllLoadedClasses();
-        ArrayList<Class> list = new ArrayList<>();
-        for (Class c : classes) {
-            System.out.println("*** " + c.getName());
-        }
-
-
         if (isDebug()) debugPrint("parsing command line arguments");
         parseArgs(args);
         if (isDebug()) debugPrint("parsed command line arguments");
@@ -445,21 +438,14 @@ public final class Main {
 
             @Override
             public void run() {
-                for (Class c : inst.getAllLoadedClasses()) {
-                    if (c != null) {
-                        System.out.println("[1] " + c.getName());
-                    }
-                }
                 try {
                     if (isDebug()) debugPrint("new Client created " + client);
                     if (client.shouldAddTransformer()) {
-                        System.out.println("*** adding transfofmer");
                         client.registerTransformer();
                         ArrayList<Class> list = new ArrayList<>();
                         if (isDebug()) debugPrint("filtering loaded classes");
                         for (Class c : inst.getAllLoadedClasses()) {
                             if (c != null) {
-                                System.out.println("[2] " + c.getName());
                                 if (inst.isModifiableClass(c) &&
                                     client.isCandidate(c)) {
                                     if (isDebug()) debugPrint("candidate " + c + " added");

--- a/src/share/classes/com/sun/btrace/agent/Main.java
+++ b/src/share/classes/com/sun/btrace/agent/Main.java
@@ -50,8 +50,10 @@ import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.util.Date;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
@@ -110,6 +112,12 @@ public final class Main {
             return;
         } else {
             Main.inst = inst;
+        }
+
+        Class[] classes = inst.getAllLoadedClasses();
+        ArrayList<Class> list = new ArrayList<>();
+        for (Class c : classes) {
+            System.out.println("*** " + c.getName());
         }
 
 
@@ -365,9 +373,11 @@ public final class Main {
 
             Client client = new FileClient(inst, traceScript, traceWriter);
 
-            handleNewClient(client);
-        } catch (RuntimeException | IOException re) {
+            handleNewClient(client).get();
+        } catch (RuntimeException | IOException | ExecutionException re) {
             if (isDebug()) debugPrint(re);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -411,9 +421,11 @@ public final class Main {
                 if (isDebug()) debugPrint("client accepted " + sock);
                 Client client = new RemoteClient(inst, sock);
                 registerExitHook(client);
-                handleNewClient(client);
-            } catch (RuntimeException | IOException re) {
+                handleNewClient(client).get();
+            } catch (RuntimeException | IOException | ExecutionException re) {
                 if (isDebug()) debugPrint(re);
+            } catch (InterruptedException e) {
+                return;
             }
         }
     }
@@ -428,30 +440,38 @@ public final class Main {
         }
     }
 
-    private static void handleNewClient(final Client client) {
-        serializedExecutor.submit(new Runnable() {
+    private static Future<?> handleNewClient(final Client client) {
+        return serializedExecutor.submit(new Runnable() {
 
             @Override
             public void run() {
+                for (Class c : inst.getAllLoadedClasses()) {
+                    if (c != null) {
+                        System.out.println("[1] " + c.getName());
+                    }
+                }
                 try {
                     if (isDebug()) debugPrint("new Client created " + client);
                     if (client.shouldAddTransformer()) {
+                        System.out.println("*** adding transfofmer");
                         client.registerTransformer();
-                        Class[] classes = inst.getAllLoadedClasses();
                         ArrayList<Class> list = new ArrayList<>();
                         if (isDebug()) debugPrint("filtering loaded classes");
-                        for (Class c : classes) {
-                            if (inst.isModifiableClass(c) &&
-                                client.isCandidate(c)) {
-                                if (isDebug()) debugPrint("candidate " + c + " added");
-                                list.add(c);
+                        for (Class c : inst.getAllLoadedClasses()) {
+                            if (c != null) {
+                                System.out.println("[2] " + c.getName());
+                                if (inst.isModifiableClass(c) &&
+                                    client.isCandidate(c)) {
+                                    if (isDebug()) debugPrint("candidate " + c + " added");
+                                    list.add(c);
+                                }
                             }
                         }
                         list.trimToSize();
                         int size = list.size();
                         if (isDebug()) debugPrint("added as ClassFileTransformer");
                         if (size > 0) {
-                            classes = new Class[size];
+                            Class[] classes = new Class[size];
                             list.toArray(classes);
                             client.startRetransformClasses(size);
                             if (isDebug()) {


### PR DESCRIPTION
Long time ago the client handling code was made asynchronous to prevent deadlocks in the GF3 monitoring framework.

The downside is that BTrace might miss and not instrument classes loaded early in the application lifecycle.

The solution is to use asynchronous client handling only for the GF3 Flashlight client and switch back to synchronous handling for everything else.